### PR TITLE
Fix unbound variable error in ssl.sh

### DIFF
--- a/wordpress-mgmt/lib/ssl.sh
+++ b/wordpress-mgmt/lib/ssl.sh
@@ -15,7 +15,8 @@ setup_ssl() {
     
     local ssl_type=$(load_state "SSL_TYPE" "letsencrypt")
     local domain=$(load_state "DOMAIN")
-    
+    local waf_type=$(load_state "WAF_TYPE" "none")
+
     case "$ssl_type" in
         "cloudflare_origin")
             setup_cloudflare_origin_ssl "$domain"


### PR DESCRIPTION
- Add missing waf_type variable initialization in setup_ssl() function
- Variable was used at line 24 but never declared
- Other functions in ssl.sh properly load this variable, setup_ssl() was missing it
- Fixes error: 'waf_type: unbound variable' during SSL setup