### PR TITLE
fix: Force update, debug report anonymization, and permissions (#32)

### DIFF
--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # ===== CONFIGURATION =====
-SCRIPT_VERSION="3.1.5"
+SCRIPT_VERSION="3.1.6"
 SCRIPT_URL="https://raw.githubusercontent.com/ait88/VPS2/main/setup-wordpress.sh"
 BASE_URL="https://raw.githubusercontent.com/ait88/VPS2/main/wordpress-mgmt"
 
@@ -191,7 +191,11 @@ force_update() {
     echo "  • All library modules in wordpress-mgmt/lib/"
     echo
 
-    if ! confirm "Proceed with force update?" Y; then
+    # Inline confirmation (confirm function not available - modules not loaded yet)
+    echo -ne "\033[1;33mProceed with force update? [Y/n]: \033[0m" >&2
+    read -r response </dev/tty
+    response=${response:-Y}
+    if [[ ! "$response" =~ ^[Yy]$ ]]; then
         info "Update cancelled"
         return 0
     fi

--- a/wordpress-mgmt/lib/wordpress.sh
+++ b/wordpress-mgmt/lib/wordpress.sh
@@ -2090,12 +2090,24 @@ ensure_wordpress_permissions() {
     sudo chmod 2770 "$wp_root/tmp"
 
     # Ensure writable directories have correct ownership for PHP-FPM
-    local writable_dirs=("wp-content/uploads" "wp-content/cache" "wp-content/upgrade" "wp-content/wflogs")
+    # Include upgrade-temp-backup subdirectories for plugin/theme updates
+    local writable_dirs=(
+        "wp-content/uploads"
+        "wp-content/cache"
+        "wp-content/upgrade"
+        "wp-content/upgrade-temp-backup"
+        "wp-content/upgrade-temp-backup/plugins"
+        "wp-content/upgrade-temp-backup/themes"
+        "wp-content/wflogs"
+    )
+
+    # Create directories if they don't exist, then set permissions
     for dir in "${writable_dirs[@]}"; do
-        if [ -d "$wp_root/$dir" ]; then
-            sudo chown php-fpm:wordpress "$wp_root/$dir"
-            sudo chmod 2775 "$wp_root/$dir"
+        if [ ! -d "$wp_root/$dir" ]; then
+            sudo mkdir -p "$wp_root/$dir"
         fi
+        sudo chown php-fpm:wordpress "$wp_root/$dir"
+        sudo chmod 2775 "$wp_root/$dir"
     done
 
     debug "WordPress permissions standardized"


### PR DESCRIPTION
## Summary

- Fix force update failing with "confirm: command not found"
- Improve debug report anonymization to prevent data leaks
- Fix WordPress permissions for plugin/theme updates and Wordfence

## Changes

### 1. Force Update Fix
- Replace `confirm()` call with inline confirmation logic
- `confirm()` from utils.sh was not available since modules aren't loaded at menu time

### 2. Debug Report Anonymization
- Fix Sites Enabled section to show count instead of leaking filenames
- Add `SFTP_WHITELIST_IPS` to IP redaction
- Add `CRON_FILE` and path variables to domain redaction  
- Improve `anonymize_log()` to handle domain-based paths like `/var/www/example.com/`
- Add fallback regex for domain-based WordPress roots
- Fix `php_version` variable scope in log section

### 3. Permissions Fix
- Add `wp-content/upgrade-temp-backup/plugins` and `themes` to writable dirs
- Add `wp-content/wflogs` to writable dirs (for Wordfence)
- Create directories if they don't exist before setting permissions
- Updated both `enforce_standard_permissions()` and `ensure_wordpress_permissions()`

Closes #32

## Test plan

- [ ] Run Force Update from menu (option 8) - should prompt and update successfully
- [ ] Generate debug report - verify no domains, IPs, or paths leak
- [ ] Run Fix/Enforce Standard Permissions - verify upgrade-temp-backup dirs created
- [ ] Check WordPress Site Health for resolved permission warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)